### PR TITLE
Fix containerstats loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"net/http"
-  _ "net/http/pprof"
 
 	"github.com/rancher/agent/cloudprovider"
 	"github.com/rancher/agent/events"
@@ -27,12 +26,6 @@ func handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-  go func() {
-  	log.Info("Launching pprof server")
-		http.HandleFunc("/", handle)
-  	http.ListenAndServe(":8080", nil)
-  }()
-
 	logserver.StartServerWithDefaults()
 	version := flag.Bool("version", false, "go-agent version")
 	rurl := flag.String("url", "", "registration url")

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"net/http"
+  _ "net/http/pprof"
 
 	"github.com/rancher/agent/cloudprovider"
 	"github.com/rancher/agent/events"
@@ -20,7 +22,17 @@ var (
 	VERSION = "dev"
 )
 
+func handle(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(r.RemoteAddr))
+}
+
 func main() {
+  go func() {
+  	log.Info("Launching pprof server")
+		http.HandleFunc("/", handle)
+  	http.ListenAndServe(":8080", nil)
+  }()
+
 	logserver.StartServerWithDefaults()
 	version := flag.Bool("version", false, "go-agent version")
 	rurl := flag.String("url", "", "registration url")

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"net/http"
 
 	"github.com/rancher/agent/cloudprovider"
 	"github.com/rancher/agent/events"
@@ -20,10 +19,6 @@ import (
 var (
 	VERSION = "dev"
 )
-
-func handle(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte(r.RemoteAddr))
-}
 
 func main() {
 	logserver.StartServerWithDefaults()

--- a/service/hostapi/stats/container_stats.go
+++ b/service/hostapi/stats/container_stats.go
@@ -153,6 +153,12 @@ func (s *ContainerStatsHandler) Handle(key string, initialMessage string, incomi
 				pidMap[cont.ID] = pid
 			}
 		}
+
+		if len(readerMap) == 0 {
+			log.Error("No monitorable containers on host; exiting to avoid synchronous infinite loop")
+			return
+		}
+
 		for {
 			infos := []containerInfo{}
 			for id, r := range readerMap {


### PR DESCRIPTION
When container stats are requested for all containers on a host with 0 containers, it triggers an infinite loop consuming 100% of available cpu. Fix is to bail out early when no containers will be monitored.